### PR TITLE
Cedato Adapter - Added support for multiple players

### DIFF
--- a/modules/cedatoBidAdapter.js
+++ b/modules/cedatoBidAdapter.js
@@ -7,7 +7,6 @@ const BID_URL = 'https://h.cedatoplayer.com/hb';
 const SYNC_URL = 'https://h.cedatoplayer.com/hb_usync';
 const TTL = 10000;
 const CURRENCY = 'USD';
-const FIRST_PRICE = 1;
 const NET_REVENUE = true;
 
 export const spec = {
@@ -25,11 +24,8 @@ export const spec = {
   },
 
   buildRequests: function(bidRequests, bidderRequest) {
-    const req = bidRequests[Math.floor(Math.random() * bidRequests.length)];
-    const params = req.params;
-    const at = FIRST_PRICE;
-    const site = { id: params.player_id, domain: document.domain };
-    const device = { ua: navigator.userAgent };
+    const site = { domain: document.domain };
+    const device = { ua: navigator.userAgent, w: screen.width, h: screen.height };
     const currency = CURRENCY;
     const tmax = bidderRequest.timeout;
     const auctionId = bidderRequest.auctionId;
@@ -39,7 +35,7 @@ export const spec = {
     const imp = bidRequests.map(req => {
       const banner = getMediaType(req, 'banner');
       const video = getMediaType(req, 'video');
-      const bidfloor = params.bidfloor;
+      const params = req.params;
       const bidId = req.bidId;
       const adUnitCode = req.adUnitCode;
       const bidRequestsCount = req.bidRequestsCount;
@@ -51,16 +47,15 @@ export const spec = {
         banner,
         video,
         adUnitCode,
-        bidfloor,
         bidRequestsCount,
         bidderWinsCount,
-        transactionId
+        transactionId,
+        params
       };
     });
 
     const payload = {
       version: '$prebid.version$',
-      at,
       site,
       device,
       imp,
@@ -83,12 +78,7 @@ export const spec = {
       }
     }
 
-    return {
-      method: 'POST',
-      url: params.bid_url || BID_URL,
-      data: JSON.stringify(payload),
-      bidderRequest
-    };
+    return formatRequest(payload, bidderRequest);
   },
 
   interpretResponse: function(resp, {bidderRequest}) {
@@ -184,6 +174,33 @@ function newBid(serverBid, bidderRequest) {
   }
 
   return bid;
+}
+
+function formatRequest(payload, bidderRequest) {
+  const payloadByUrl = {};
+  const requests = [];
+
+  payload.imp.forEach(imp => {
+    const url = imp.params.bid_url || BID_URL;
+    if (!payloadByUrl[url]) {
+      payloadByUrl[url] = {
+        ...payload,
+        imp: []
+      };
+    }
+    payloadByUrl[url].imp.push(imp);
+  });
+
+  for (const url in payloadByUrl) {
+    requests.push({
+      url,
+      method: 'POST',
+      data: JSON.stringify(payloadByUrl[url]),
+      bidderRequest
+    });
+  }
+
+  return requests;
 }
 
 const getSync = (type, gdprConsent, uspConsent = '') => {

--- a/test/spec/modules/cedatoBidAdapter_spec.js
+++ b/test/spec/modules/cedatoBidAdapter_spec.js
@@ -50,12 +50,12 @@ describe('the cedato adapter', function () {
     });
 
     it('should build a very basic request', function() {
-      var request = spec.buildRequests([bid], bidRequestObj);
+      var [request] = spec.buildRequests([bid], bidRequestObj);
       expect(request.method).to.equal('POST');
     });
 
     it('should pass gdpr and usp strings to server', function() {
-      var request = spec.buildRequests([bid], bidRequestObj);
+      var [request] = spec.buildRequests([bid], bidRequestObj);
       var payload = JSON.parse(request.data);
       expect(payload.gdpr_consent).to.not.be.undefined;
       expect(payload.gdpr_consent.consent_string).to.equal(bidRequestObj.gdprConsent.consentString);


### PR DESCRIPTION
Changes:

- removed `site.player_id`
- forward `params` from each request to its appropriate `imp` struct
- added `device.w` and `device.h` 
- removed redundant `at` attribute
- split requests to fulfil custom `bid_url` attribute on `imp` level